### PR TITLE
chore: delete the committed ktlint binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Built application files
 /*/build/
 
+# ktlint binary (fetch locally if needed, don't commit it)
+/ktlint
+
 # Crashlytics configuations
 com_crashlytics_export_strings.xml
 


### PR DESCRIPTION
## Summary

Deletes the 38 MB `ktlint` executable committed at the repo root and adds `/ktlint` to `.gitignore` so it can't be re-added by accident.

## What this does NOT do

- **No history rewrite.** The binary stays in old commits/the pack file - the issue calls that optional and not worth it for a repo this size.
- **No ktlint Gradle plugin.** The issue mentions wiring ktlint in as a plugin as an option, but the build is currently broken and unverifiable (see #35/#37/#41), so adding a plugin right now risks breaking it further without any way to confirm it still works. Left for a follow-up once the build is green again.

## Test plan

- [x] `git ls-files | grep ktlint` returns nothing
- [x] `.gitignore` has `/ktlint`

Closes #38