### PR TITLE
ci: add build + unit test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       # Gradle 5.6.4 (this project's wrapper version) supports at most JDK 12;
       # 8 is what AGP 3.6.2 / this project were actually built and tested against.
       # Expected to go red until the Gradle/AGP/Kotlin upgrade (#35/#37/#41) lands.
-      - uses: actions/setup-java@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Gradle 5.6.4 (this project's wrapper version) supports at most JDK 12;
+      # 8 is what AGP 3.6.2 / this project were actually built and tested against.
+      # Expected to go red until the Gradle/AGP/Kotlin upgrade (#35/#37/#41) lands.
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: gradle
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`: on push to `master` and on every pull request, checkout → set up JDK → `./gradlew assembleDebug` → `./gradlew testDebugUnitTest`, with Gradle dependency caching via `actions/setup-java`'s built-in `cache: gradle`.

## JDK choice

**Temurin 8.** This project's wrapper is Gradle 5.6.4 with AGP 3.6.2 and Kotlin 1.3.72 (all from 2020). Gradle 5.6.4 itself can run under JDK 8 through 12, but AGP 3.6.2's own tooling support for JDK 11+ wasn't added until AGP 4.1 - JDK 8 is what this specific Gradle/AGP combination was actually built and tested against, so it gives the build the most honest chance of getting past setup before hitting real incompatibilities.

## This is expected to fail

The project doesn't build on a modern toolchain yet - upgrading Gradle/AGP/Kotlin is #35/#37/#41, not this PR. This workflow is intentionally **not** `continue-on-error` and does nothing to force a green run. A red check here is the accurate, honest baseline; it goes green once the upgrade lands.

## Test plan

- [x] Workflow YAML is valid (`push`/`pull_request` triggers, `actions/checkout@v7`, `actions/setup-java@v5`)
- [x] First actual run confirmed: `assembleDebug` **passed** (JDK 8 gets the app module compiling and packaging fine); `testDebugUnitTest` **failed** on a pre-existing compile error in `common/src/test/.../NightsOutSharedPreferencesTest.kt` (`Null can not be a value of a non-null type WeightMeasurement`) - a real bug in the test source, not a CI wiring issue. That's the honest baseline this issue asked for.

Closes #40