### PR TITLE
fix(common): pass a real WeightMeasurement in the shared-prefs test

### DIFF
--- a/common/src/test/java/com/fagerberg/jason/common/android/NightsOutSharedPreferencesTest.kt
+++ b/common/src/test/java/com/fagerberg/jason/common/android/NightsOutSharedPreferencesTest.kt
@@ -44,7 +44,7 @@ class NightsOutSharedPreferencesTest {
             profileInit = false,
             sex = null,
             weight = 0.0,
-            weightMeasurement = null,
+            weightMeasurement = WeightMeasurement.LBS,
             startTimeMin = 0,
             endTimeMin = 0,
             use24HourTime = false,


### PR DESCRIPTION
## Why

`NightsOutSharedPreferencesTest.kt` fails to compile: it constructs `NightsOutSharedPreferences(weightMeasurement = null, ...)`, but `weightMeasurement` is a non-null `WeightMeasurement`. Only `sex` is nullable.

That's not an accident. `#33` (the new profile module) deliberately changed `weightMeasurement` from `WeightMeasurement?` to `WeightMeasurement`, and switched `getNightsOutSharedPreferences()` from a plain nullable read to one with a country-based fallback default (LBS/KG). `sex` got no such default — it stays `Boolean?` because "unset" is a real, meaningful state for it (no reasonable default exists), and every read site (`ProfileFragmentViewManager.renderPreferences`) still null-checks it with `sharedPreferences.sex?.let { ... }`.

`weightMeasurement`, by contrast, is read unconditionally with no null-safety anywhere downstream — `ProfileFragmentViewManager.renderPreferences` does `sharedPreferences.weightMeasurement.displayName` directly, and `ProfileFragmentPresenter`/`ProfileFragmentRepository` all type their save path as non-null `WeightMeasurement`. Production guarantees a value is always present; the test just never got updated when the type changed.

## What

- `NightsOutSharedPreferencesTest.kt`: fixture's `weightMeasurement` is now `WeightMeasurement.LBS` instead of `null` (the "before update" value, distinct from the `WeightMeasurement.KG` used as the "after update" value later in the same test, so the assertion still exercises a real change).

`sex = null` is untouched — it's the correct nullable case.

## Verification

Can't build locally (no JDK/Android SDK on this box). Pushed and watching CI (`assembleDebug` + `testDebugUnitTest` on JDK 8) on this PR until both are green.

Closes #71