### PR TITLE
build: drop legacy-support-v4 and raise minSdk to 24 (closes #45, closes #46)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 36
     defaultConfig {
         applicationId "com.wit.jasonfagerberg.nightsout"
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 36
         versionCode 1904
         versionName "Rattata"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    // ViewPager was transitive via legacy-support-v4; MainActivity uses it
+    implementation 'androidx.viewpager:viewpager:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     // jetified like the calendar AAR; core classes reference support ViewCompat/EdgeEffectCompat
     implementation files('libs/graphview-4.2.2-androidx.aar')

--- a/common-dialog/build.gradle
+++ b/common-dialog/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
     implementation "io.reactivex.rxjava2:rxjava:2.2.6"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Why

Two build-hygiene items from the modernization roadmap:

- **#45**: `androidx.legacy:legacy-support-v4:1.0.0` is a meta-package that pulled a dozen transitive artifacts into `app` and `profile`, almost none of which the code uses.
- **#46**: `minSdkVersion 19` (KitKat, 2013) sits below the floor of every current AndroidX release and forces multidex/desugaring workarounds for no real user benefit. API 24 is the modernization plan's recommended floor; Play Console install stats can still veto the number before release, per #46.

## What changed

- `65095b6` **build: drop legacy-support-v4 meta-package** — removed from `app/build.gradle` and `profile/build.gradle`; added `androidx.viewpager:viewpager:1.0.0` to `app`.
- `2f89c49` **build: raise minSdk from 19 to 24** — `defaultConfig` in all five modules: app, common, common-dialog, db, profile.

## How

Grepped app and profile sources for androidx imports: the only class that came solely from the legacy meta-package is `androidx.viewpager.widget.ViewPager` (`MainActivity.kt` + `activity_main.xml`), so `androidx.viewpager:viewpager:1.0.0` is now declared explicitly in `app`. Everything else the sources import — `androidx.fragment`, `androidx.recyclerview`, `androidx.cardview`, `androidx.core` — still arrives transitively via appcompat and material, confirmed with `app/profile:dependencies` rather than assumed. Nothing was added back to `profile`: its six androidx imports are all covered transitively.

Artifacts that left the app compile classpath: legacy-support-v4, legacy-support-core-ui, legacy-support-core-utils, media, localbroadcastmanager, print, slidingpanelayout, swiperefreshlayout, asynclayoutinflater, documentfile (plus stale 1.0.0 entries for coordinatorlayout/versionedparcelable that newer versions already supersede). None are referenced in the sources.

## Verification

From clean:

```
./gradlew clean assembleDebug assembleRelease testDebugUnitTest
# BUILD SUCCESSFUL in 1m 2s — 304 actionable tasks: 266 executed, 38 up-to-date
```

Dependency graph proof:

```
./gradlew app:dependencies --configuration debugRuntimeClasspath | grep legacy-support
# (no matches, grep exit 1)
```

`androidx.viewpager:viewpager:1.0.0` is present in the graph as a direct dependency; `profile:dependencies --configuration debugCompileClasspath` also shows zero legacy-support matches while retaining fragment 1.1.0, recyclerview 1.1.0, cardview 1.0.0, and core 1.2.0 transitively.

## Out of scope

- Bumping the older androidx pins (appcompat 1.1.0, material 1.1.0, constraintlayout 1.1.3) — separate modernization steps.
- Confirming API 24 against Play Console install stats; that check can still veto the number before the next release.