### PR TITLE
build: enable R8 for release builds (closes #47)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,8 @@ android {
     }
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,23 +1,11 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in show.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Issue #47 audit: no class keep rules required. App code uses no reflection
+# (no Class.forName/getDeclaredMethod) and no JSON/Java serialization
+# (SharedPreferences stores primitives only). Custom views in layouts and
+# manifest components are kept by AGP-generated rules. threetenabp reads
+# TZDB.dat from assets (exempt from resource shrinking) and registers its
+# ZoneRulesProvider directly, no ServiceLoader.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
+# Keep file/line info so release stack traces stay debuggable
 -keepattributes SourceFile,LineNumberTable
-# rename the source files to something meaningless, but it must be retained
+# Collapse source file names since line numbers above are retained
 -renamesourcefileattribute ''
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile


### PR DESCRIPTION
## Why

Release builds shipped with `isMinifyEnabled = false`, so the release APK carried all dead code and full symbol names. Issue #47 asks for shrinking/obfuscation on release.

## What changed

- `app/build.gradle.kts` release block: `isMinifyEnabled = true` + `isShrinkResources = true`. The existing `proguardFiles` line (`proguard-android-optimize.txt` + `proguard-rules.pro`) is unchanged.
- `app/proguard-rules.pro`: no new keep rules needed (audit below); kept the existing line-number attributes and replaced the stale template boilerplate with the audit conclusion so the empty rule set reads as deliberate.

## How (audit findings)

Grepped all app sources and decompiled the two bundled jetified AARs plus threetenabp before flipping the flag:

- **No class reflection in app code** — zero hits for `Class.forName`, `getDeclaredMethod`, `getConstructor`, `newInstance`, `getIdentifier(`.
- **No serialization** — no gson/moshi/kotlinx/jackson/org.json anywhere, no `Serializable`/`Parcelable`; SharedPreferences stores primitives only.
- **Layouts** — no `android:onClick`, no `<fragment>` tags. Custom views referenced from layouts (`GraphView`, `MaterialCalendarView`, `DrinkSuggestionAutoCompleteView`) and manifest components (Application, 4 activities, 1 service) are kept by AGP/AAPT-generated rules — verified kept in `mapping.txt`.
- **MaterialCalendarView (calendarview AAR)** — its only reflection-adjacent call is `Resources.getIdentifier("colorAccent", "attr", pkg)`, a resource lookup with constant args, which R8 traces. Verified `attr/colorAccent` stays reachable in the shrunk resource table via appcompat theme overlays.
- **threetenabp 1.1.1** — `AssetsZoneRulesInitializer` reads `org/threeten/bp/TZDB.dat` from **assets** (untouched by `shrinkResources`) and registers `TzdbZoneRulesProvider` via a direct `ZoneRulesProvider.registerProvider` call. The threetenbp no-tzdb jar ships an empty `META-INF/services` — no ServiceLoader, no keep rule needed.
- **R8 warnings** — clean `minifyReleaseWithR8` run with zero missing-class warnings from the jetified AARs' androidx references, so no `dontwarn` entries were added.

## Verification

- `./gradlew clean assembleDebug assembleRelease testDebugUnitTest` — all pass (15 unit tests, 0 failures). R8 ran with no warnings.
- Release APK size (`app/build/outputs/apk/release/`): **3,406,884 B before → 1,496,764 B after (−56%)**.
- Verified in R8 outputs: 943 classes obfuscated, `MainActivity`/`NightsOutApplication`/`BacNotificationService`/custom views kept, usage report shows dead-code removal.
- **Not verified: runtime behavior.** No emulator/device available here — I could not launch the release APK.

## Review focus

- **A device smoke test of the release APK is still required before any store upload** — R8 issues surface at runtime, not at build time. Exercise: app start (threetenabp init), log tab (MaterialCalendarView), profile graph (GraphView), add-drink autocomplete (custom view), settings.
- Confirm you're comfortable with an empty app-specific keep set (justified in `proguard-rules.pro` comments).

## Out of scope

- Signing config for release (APK is unsigned, same as before).
- Enabling configuration cache / other build-speed work.

Closes #47