### PR TITLE
refactor: extract Widmark BAC calculation (closes #49)

### DIFF
--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/domain/BacCalculator.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/domain/BacCalculator.kt
@@ -1,0 +1,42 @@
+package com.wit.jasonfagerberg.nightsout.domain
+
+/**
+ * Widmark BAC formula, imperial due to better floating point accuracy.
+ * Pure Kotlin: callers normalize units with Converter before calling.
+ */
+object BacCalculator {
+    private const val ALCOHOL_OZ_TO_BAC = 5.14
+    private const val R_MALE = 0.73
+    private const val R_FEMALE = 0.66
+    private const val BAC_DECAY_PER_HOUR = 0.015
+    private const val MINUTES_IN_DAY = 1440
+
+    class Drink(val volumeFluidOz: Double, val abvPercent: Double)
+
+    /**
+     * @param weightLbs 0.0 divides by zero, yielding NaN (no drinks) or
+     * +Infinity (with drinks); preserved from the original math.
+     */
+    fun calculate(drinks: List<Drink>, weightLbs: Double, male: Boolean,
+                  startTimeMin: Int, endTimeMin: Int): Double {
+        val r = if (male) R_MALE else R_FEMALE
+        val instantBac = (alcoholOz(drinks) * ALCOHOL_OZ_TO_BAC) / (weightLbs * r)
+        val bac = instantBac - (hoursElapsed(startTimeMin, endTimeMin) * BAC_DECAY_PER_HOUR)
+        return if (bac < 0.0) 0.0 else bac
+    }
+
+    // total pure alcohol in fl oz across all drinks
+    fun alcoholOz(drinks: List<Drink>): Double {
+        var total = 0.0
+        for (drink in drinks) {
+            total += drink.volumeFluidOz * (drink.abvPercent / 100)
+        }
+        return total
+    }
+
+    // wraps past midnight when end precedes start
+    fun hoursElapsed(startTimeMin: Int, endTimeMin: Int): Double {
+        return if (endTimeMin < startTimeMin) ((endTimeMin + MINUTES_IN_DAY) - startTimeMin) / 60.0
+        else (endTimeMin - startTimeMin) / 60.0
+    }
+}

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/home/HomeFragment.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/home/HomeFragment.kt
@@ -23,6 +23,7 @@ import com.wit.jasonfagerberg.nightsout.dialogs.BacInfoDialog
 import com.wit.jasonfagerberg.nightsout.dialogs.LightSimpleDialog
 import com.wit.jasonfagerberg.nightsout.dialogs.SimpleDialog
 import com.wit.jasonfagerberg.nightsout.constants.Constants
+import com.wit.jasonfagerberg.nightsout.domain.BacCalculator
 import com.wit.jasonfagerberg.nightsout.main.MainActivity
 import com.wit.jasonfagerberg.nightsout.manageDB.ManageDBActivity
 import java.util.*
@@ -254,37 +255,20 @@ class HomeFragment : Fragment() {
         dialog.setNeutralFunction { dialog.dismiss() }
     }
 
-    // Widemark formula, imperial due to better floating point accuracy
+    // Widmark formula lives in BacCalculator; side effects (stats, notification) stay here
     fun calculateBAC(): Double {
-        var a = 0.0
-        for (drink in mMainActivity.mDrinksList) {
-            val volume = mConverter.drinkVolumeToFluidOz(drink.amount, drink.measurement)
-            val abv = drink.abv / 100
-            a += (volume * abv)
+        val drinks = mMainActivity.mDrinksList.map {
+            BacCalculator.Drink(mConverter.drinkVolumeToFluidOz(it.amount, it.measurement), it.abv)
         }
-        standardDrinksConsumed = mConverter.fluidOzToGrams(a) / 14.0
-
-        val r = if (mMainActivity.sex!!) .73 else .66
+        standardDrinksConsumed = mConverter.fluidOzToGrams(BacCalculator.alcoholOz(drinks)) / 14.0
+        drinkingDuration = BacCalculator.hoursElapsed(mMainActivity.startTimeMin, mMainActivity.endTimeMin)
 
         val weightInLbs = mConverter.weightToLbs(mMainActivity.weight, mMainActivity.weightMeasurement)
+        val bac = BacCalculator.calculate(drinks, weightInLbs, mMainActivity.sex!!,
+                mMainActivity.startTimeMin, mMainActivity.endTimeMin)
 
-        val sexModifiedWeight = weightInLbs * r
-
-        val instantBAC = (a * 5.14) / sexModifiedWeight
-
-        var hoursElapsed = (mMainActivity.endTimeMin - mMainActivity.startTimeMin) / 60.0
-        if (mMainActivity.endTimeMin < mMainActivity.startTimeMin) {
-            val minInDay = 1440
-            hoursElapsed = ((mMainActivity.endTimeMin + minInDay) - mMainActivity.startTimeMin) / 60.0
-        }
-
-        drinkingDuration = hoursElapsed
-
-        val bacDecayPerHour = 0.015
-        var res = instantBAC - (hoursElapsed * bacDecayPerHour)
-        res = if (res < 0.0) 0.0 else res
         mMainActivity.sendActionToBacNotificationService(Constants.ACTION.UPDATE_NOTIFICATION)
-        return res
+        return bac
     }
 
     fun updateBACText(update: Double) {

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/notification/BacNotificationService.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/notification/BacNotificationService.kt
@@ -11,6 +11,7 @@ import com.wit.jasonfagerberg.nightsout.R
 import com.wit.jasonfagerberg.nightsout.addDrink.AddDrinkActivity
 import com.wit.jasonfagerberg.nightsout.utils.Converter
 import com.wit.jasonfagerberg.nightsout.databaseHelper.DatabaseHelper
+import com.wit.jasonfagerberg.nightsout.domain.BacCalculator
 import com.wit.jasonfagerberg.nightsout.constants.Constants
 import com.wit.jasonfagerberg.nightsout.main.MainActivity
 import com.wit.jasonfagerberg.nightsout.main.NightsOutApplication
@@ -130,32 +131,13 @@ class BacNotificationService : Service() {
         dbh.openDatabase()
         getPreferencesData()
 
-        var a = 0.0
-        for (drink in dbh.pullCurrentSessionDrinks()) {
-            val volume = mConverter.drinkVolumeToFluidOz(drink.amount, drink.measurement)
-            val abv = drink.abv / 100
-            a += (volume * abv)
+        val drinks = dbh.pullCurrentSessionDrinks().map {
+            BacCalculator.Drink(mConverter.drinkVolumeToFluidOz(it.amount, it.measurement), it.abv)
         }
-
-        val r = if (sex) .73 else .66
+        dbh.closeDatabase()
 
         val weightInLbs = mConverter.weightToLbs(weight, weightMeasurement)
-
-        val sexModifiedWeight = weightInLbs * r
-
-        val instantBAC = (a * 5.14) / sexModifiedWeight
-
-        var hoursElapsed = (endTime - startTime) / 60.0
-        if (endTime < startTime) {
-            val minInDay = 1440
-            hoursElapsed = ((endTime + minInDay) - startTime) / 60.0
-        }
-
-        val bacDecayPerHour = 0.015
-        var res = instantBAC - (hoursElapsed * bacDecayPerHour)
-        res = if (res < 0.0) 0.0 else res
-        dbh.closeDatabase()
-        return res
+        return BacCalculator.calculate(drinks, weightInLbs, sex, startTime, endTime)
     }
 
     override fun onBind(intent: Intent): IBinder? {

--- a/app/src/test/java/com/wit/jasonfagerberg/nightsout/domain/BacCalculatorTest.kt
+++ b/app/src/test/java/com/wit/jasonfagerberg/nightsout/domain/BacCalculatorTest.kt
@@ -1,0 +1,72 @@
+package com.wit.jasonfagerberg.nightsout.domain
+
+import com.wit.jasonfagerberg.nightsout.domain.BacCalculator.Drink
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Test
+
+class BacCalculatorTest {
+
+    // 12 oz beer at 5% -> 0.6 fl oz pure alcohol; 180 lbs male -> 131.4
+    // 0.6 * 5.14 / 131.4 = 0.02347031963...
+    @Test
+    fun `single drink matches hand-computed Widmark reference value`() {
+        val drinks = listOf(Drink(12.0, 5.0))
+
+        assertThat(BacCalculator.calculate(drinks, 180.0, true, 780, 780))
+                .isCloseTo(0.0234703196, within(1e-9))
+        // female: 180 * 0.66 = 118.8 -> 3.084 / 118.8 = 0.02595959595...
+        assertThat(BacCalculator.calculate(drinks, 180.0, false, 780, 780))
+                .isCloseTo(0.0259595960, within(1e-9))
+    }
+
+    // beer 0.6 + wine 5oz@12% 0.6 + shot 1.5oz@40% 0.6 = 1.8 fl oz
+    // 1.8 * 5.14 / 131.4 = 0.07041095890...
+    @Test
+    fun `multiple drinks accumulate alcohol`() {
+        val drinks = listOf(Drink(12.0, 5.0), Drink(5.0, 12.0), Drink(1.5, 40.0))
+
+        assertThat(BacCalculator.calculate(drinks, 180.0, true, 780, 780))
+                .isCloseTo(0.0704109589, within(1e-9))
+    }
+
+    // 4 beers -> 2.4 fl oz -> instant 0.09388127853...; 2h decay = 0.03
+    @Test
+    fun `bac decays 0 point 015 per hour elapsed`() {
+        val drinks = listOf(Drink(48.0, 5.0))
+
+        assertThat(BacCalculator.calculate(drinks, 180.0, true, 780, 900))
+                .isCloseTo(0.0638812785, within(1e-9))
+    }
+
+    @Test
+    fun `bac clamps to zero when decay exceeds instant bac`() {
+        val drinks = listOf(Drink(12.0, 5.0))
+
+        // 0.0234703... - 2 * 0.015 < 0
+        assertThat(BacCalculator.calculate(drinks, 180.0, true, 780, 900)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `end time before start time wraps past midnight`() {
+        val drinks = listOf(Drink(48.0, 5.0))
+
+        assertThat(BacCalculator.hoursElapsed(1380, 60)).isEqualTo(2.0)
+        assertThat(BacCalculator.hoursElapsed(60, 1380)).isEqualTo(22.0)
+        // 23:00 -> 01:00 is 2h: same as the decay case above
+        assertThat(BacCalculator.calculate(drinks, 180.0, true, 1380, 60))
+                .isCloseTo(0.0638812785, within(1e-9))
+    }
+
+    // original math divides by zero on unset weight; documented, not changed
+    @Test
+    fun `zero or blank weight divides by zero per original math`() {
+        val drinks = listOf(Drink(12.0, 5.0))
+
+        assertThat(BacCalculator.calculate(drinks, 0.0, true, 780, 780))
+                .isEqualTo(Double.POSITIVE_INFINITY)
+        assertThat(BacCalculator.calculate(emptyList(), 0.0, true, 780, 780).isNaN()).isTrue()
+        // blank weight input converts to NaN via Converter.stringToDouble("")
+        assertThat(BacCalculator.calculate(drinks, Double.NaN, true, 780, 780).isNaN()).isTrue()
+    }
+}


### PR DESCRIPTION
## Why

Closes #49. The BAC shown on the home screen and in the persistent notification was computed by two separate, untested copies of the Widmark formula: one in `HomeFragment.calculateBAC()`, one in `BacNotificationService.calculateBAC()`. A fix applied to only one copy would make the app's core number disagree with itself across screens, and nothing would catch it.

## What changed

- New `domain/BacCalculator.kt`: one pure-Kotlin implementation of the Widmark formula (volume×abv accumulation, .73/.66 sex constant, ×5.14, 0.015/hr decay, clamp at 0, overnight wrap when end < start).
- `HomeFragment` and `BacNotificationService` both call it now. Call sites normalize units with the existing `Converter` and keep their own side effects (session stats, notification refresh).
- New `domain/BacCalculatorTest.kt`: 6 unit tests.

## How

**The two copies were line-for-line identical in math**; there was no divergence to reconcile. They differed only in data source (DB pull in the service vs in-memory list in the fragment) and in the fragment's side effects (`standardDrinksConsumed`, `drinkingDuration`, notification update), all of which stay at the call sites.

Inputs arrive normalized: drinks become `BacCalculator.Drink(volumeFluidOz, abvPercent)` via `Converter.drinkVolumeToFluidOz`, weight becomes lbs via `Converter.weightToLbs`. The calculator has no Android dependencies and runs in plain JVM tests.

One edge for the reviewer's eyes: with an unset (0.0) weight the math divides by zero, yielding NaN with no drinks and +Infinity with drinks. Profile validation requires weight ≥ 20 before the formula is reachable, so normal flow never hits this. I preserved the existing behavior exactly and documented it with a test rather than silently changing what the app displays; say the word if you'd rather clamp or guard it here.

## Verification

`./gradlew clean assembleDebug assembleRelease testDebugUnitTest` — BUILD SUCCESSFUL. Unit tests 15 → 21 (6 new), all passing: hand-computed Widmark reference values (male and female), multi-drink accumulation, hourly decay, clamp-to-zero floor, overnight wrap, and the zero/NaN-weight edge.

## Out of scope

- Guarding or surfacing the unset-weight edge in the UI (profile validation already prevents it).
- `BacInfoDialog`'s "hours to sober" estimate, which reuses the 0.015 decay constant but is not a copy of the formula.
