### PR TITLE
docs: refresh OpenWiki after M1 and #82

### DIFF
--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-26T03:43:08.584Z",
+  "updatedAt": "2026-07-26T05:26:03.510Z",
   "command": "update",
-  "gitHead": "b8c4c94891921f5d7fe3b5695d9930d3d7ec0643",
+  "gitHead": "a9d8c8f42ca934569321906ccc2f0163c5473948",
   "model": "qwen3.6-35b"
 }

--- a/openwiki/architecture/index.md
+++ b/openwiki/architecture/index.md
@@ -1,3 +1,3 @@
 # Files
 
-- [NightsOut — Architecture Overview](overview.md) - Module structure, dependency graph, build configuration, and architectural patterns across the five Gradle modules of the NightsOut BAC calculator Android app.
+- [NightsOut — Architecture Overview](overview.md) - Single-module project structure, build configuration (Kotlin DSL + version catalog), and architectural patterns for the NightsOut BAC calculator Android app.

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -1,157 +1,142 @@
 ---
 type: Architecture Overview
 title: NightsOut — Architecture Overview
-description: Module structure, dependency graph, build configuration, and architectural patterns across the five Gradle modules of the NightsOut BAC calculator Android app.
+description: Single-module project structure, build configuration (Kotlin DSL + version catalog), and architectural patterns for the NightsOut BAC calculator Android app.
+resource: https://github.com/jasonfagerberg/NightsOut
+tags: [architecture]
+timestamp: 2025-07-26T04:30:00Z
 ---
 
 # Architecture Overview
 
-NightsOut is structured as a **5-module Android project** using Gradle subprojects. The architecture balances code reuse (shared models in `common`) with module-level separation of concerns (database, UI, profile MVI logic).
+NightsOut is a **single-module (`:app`) Android project** using Gradle Kotlin DSL with a version catalog for dependency management. The architecture uses direct data binding (no ViewModels, LiveData, Room, or Coroutines) across all screens — the `domain.BacCalculator` object is the only pure-Kotlin library code.
 
-## Module Dependency Graph
+## Project Structure on Disk
 
 ```
-┌───────────────┐     ┌───────────────────┐
-│    common     │────▶│   common-dialog    │
-│  (models, util)│    │ (dialogs only)     │
-└───────┬───────┘     └───────────────────┘
-        │                     ▲
-        ├── depends on ───────┘
-        │
-        ▼
-┌───────────────┐     ┌───────────────────┐
-│      db       │◀────│    profile         │
-│ (SQLite CRUD) │     │ (MVI presenter)   │
-└───────┬───────┘     └───────────────────┘
-        │                    ▲
-        │ depends on         │ depends on
-        ▼                    │
-┌────────────────────────────┼────────────────────────────┐
-│                            ▼                            │
-│                      app                                │
-│             (Activities, Fragments, Services)           │
-└─────────────────────────────────────────────────────────┘
+/app/                                  # Only Gradle module (:app)
+├── src/main/java/com/wit/jasonfagerberg/nightsout/
+│   ├── domain/      ← BacCalculator (pure Kotlin, no Android deps)
+│   ├── models/      ← Drink, LogHeader, VolumeMeasurement, WeightMeasurement
+│   ├── utils/       ← Converter, CountryUtils
+│   ├── main/        ← MainActivity, NightsOutActivity (base), NightsOutApplication
+│   ├── home/        ← HomeFragment + drink/log list adapters
+│   ├── addDrink/    ← AddDrinkActivity, ComplexDrinkHelper, suggestions
+│   ├── log/         ← Session logging UI
+│   ├── profile/     ← ProfileFragment + favorites adapter (flat data binding)
+│   ├── notification ← BacNotificationService (foreground service)
+│   ├── dialogs/     ← SimpleDialog, LightSimpleDialog, BacInfoDialog, EditDrinkDialog
+│   ├── databaseHelper/ ← DatabaseHelper, AddDrinkDatabaseHelper, LogDatabaseHelper
+│   ├── constants/   ← AppConstants
+│   └── settings/    ← SettingsActivity
+├── src/main/assets/     ← nights_out_db.db (pre-populated, version 40)
+└── libs/                ← Local AARs: graphview-4.2.2-androidx.aar, material-calendarview-2.0.1-androidx.aar
+/gradle/libs.versions.toml  # Version catalog for all dependencies
+/settings.gradle.kts       # include(":app") — single module
+/app/build.gradle.kts      # Build config: Kotlin DSL
+.github/workflows/ci.yml   # CI build + test workflow
 ```
 
-| Module | Type | Depends On | Depends By | Description |
-|--------|------|------------|------------|-------------|
-| [`:common`](/common/src/main/java/com/fagerberg/jason/common/) | Android Library | (none) | app, db, common-dialog, profile | Shared models, utilities, base classes, SharedPreferences wrapper |
-| [`:db`](/db/src/main/java/com/wit/jasonfagerberg/nightsout/db/) | Android Library | `:common` | app | SQLite data layer with pre-populated database |
-| [`:profile`](/profile/src/main/java/com/fagerberg/jason/profile/) | Android Library | `:common`, `:db`, `:common-dialog` | (none directly) | MVI-powered profile screen; not consumed at runtime by app module — the app uses its own ProfileFragment instead. See note below. |
-| [`:common-dialog`](/common-dialog/src/main/java/com/fagerberg/jason/common/dialog/) | Android Library | `:common` | profile | Reusable dialog components (SimpleDialog, LightSimpleDialog) |
-| [`:app`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/) | Android Application | `:common`, `:db`, `:profile`, `:common-dialog` | (none) | Main app with Activities, Fragments, adapters, services |
+The former `:common`, `:db`, `:profile`, and `:common-dialog` submodules were harvested into `:app` in refactor v0.78 (#78). See **[Quickstart — Architecture at a Glance](./quickstart.md#architecture-at-a-glance)** for a summary of the previous 5-module structure.
 
 ## Configuration Summary
 
 | Setting | Value |
 |---------|-------|
-| **Compile SDK** | 36 (Android 16) |
-| **Min SDK** | 19 (Android 4.4 KitKat) |
-| **Target SDK** | 36 (Android 16) |
-| **Kotlin Version** | 1.3.72 (older — may need upgrade to match AGP 9.x) |
-| **Build Tools / AGP** | 9.3.1 |
+| **Namespace** | `com.wit.jasonfagerberg.nightsout` |
+| **Compile / Target SDK** | 36 (Android 16) |
+| **Min SDK** | 24 (Android 7.0 Nougat) |
+| **Kotlin Version** | 2.2.10 (per version catalog) |
+| **AGP** | 9.3.1 |
+| **KSP** | 2.2.10-2.0.2 |
 | **Application ID** | `com.wit.jasonfagerberg.nightsout` |
+| **Version** | 1904 ("Rattata") |
 
-### Key Dependencies (common to app)
+Dependencies are declared via the [version catalog](../gradle/libs.versions.toml). Key runtime dependencies:
 
-| Dependency | Purpose |
-|------------|---------|
-| `androidx.appcompat:appcompat:1.1.0` | Base AndroidX components |
-| `com.google.android.material:material:1.1.0` | Material Components (buttons, navigation bars, dialogs) |
-| `androidx.constraintlayout:constraintlayout:1.1.3` | Layout engine |
-| `androidx.preference:preference:1.1.1` | Settings UI |
-| Local AAR `graphview-4.2.2-androidx.aar` (jetified) | BAC decline chart rendering |
-| Local AAR `material-calendarview-2.0.1-androidx.aar` (jetified) | Calendar picker in Log fragment |
-| `io.reactivex.rxjava2:rxjava:2.2.6` + `rxandroid:2.1.1` | Reactive streams for MVI (profile module) |
-| `com.jakewharton.rxrelay2:rxrelay:2.1.1` | Replay subject support for AbstractPresenter |
+| Dependency (catalog alias) | Version | Purpose |
+|---------------------------|---------|---------|
+| `libs.appcompat` | 1.1.0 | Base AndroidX components |
+| `libs.material` | 1.1.0 | Material Components |
+| `libs.constraintlayout` | 1.1.3 | Layout engine |
+| `libs.preference` | 1.1.1 | Settings UI |
+| `libs.viewpager` | 1.0.0 | ViewPager support |
+| `libs.threetenabp` | 1.1.1 | Date/time utilities (used by material-calendarview) |
+
+The project declares Room and Koin as dependencies in the version catalog, but neither is actively used in source code — they may be vestigial or intended for future migration from direct SQLite access.
 
 ## Architectural Patterns
 
-### 1. Flat Data Binding (Primary — App Module)
+### 1. Flat Data Binding (All Screens)
 
-Most of the app follows a direct, flat architecture without modern AndroidX components:
+Every screen uses direct view references with `lateinit var` bindings backed by `SharedPreferences` for persistence:
 
 ```
 Activity/Fragment → DatabaseHelper (SQLiteOpenHelper) → SQLite
                     ↓
-                SharedPreferences (settings)
+                SharedPreferences (settings via PreferenceManager)
 ```
 
 - **No ViewModel, LiveData, Room, or Coroutines.** Data is accessed directly from database helpers in response to user interactions.
 - `MainActivity` holds **in-memory state** (current drinks, favorites, log headers) and persists on `onStop()`.
 - Three specialized helper classes wrap the base `DatabaseHelper`: `AddDrinkDatabaseHelper`, `LogDatabaseHelper`.
 
-### 2. MVI with RxJava (Profile Module)
+### 2. Pure-Kotlin BAC Domain (`domain/`)
 
-The profile module implements a clean MVI (Model-View-Intent) architecture using the shared `AbstractPresenter` base class from `common`:
+**Source:** [`domain/BacCalculator.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/domain/BacCalculator.kt)
+
+The BAC calculation was extracted into a pure-Kotlin `object` with no Android dependencies (#82). This enables JVM-only unit tests without an emulator:
 
 ```
-Intent (user action) → AbstractPresenter.intentToAction() → ProfileAction
-    ↓
-actionToResult() [RxJava Observable, runs on Schedulers.io()]
-    ↓
-stateReducer(previousState, result) → ProfileViewModel
-    ↓
-viewModelStream().observeOn(mainThread()) → View renders state
+HomeFragment.calculateBAC()  → Converter normalizes units → BacCalculator.calculate(drinks, weightLbs, male, startTimeMin, endTimeMin)
+BacNotificationService.calculateBAC()  → DatabaseHelper.pullCurrentSessionDrinks() → Converter normalizes → BacCalculator.calculate(...)
 ```
 
-The `AbstractPresenter` is a subclass of `AndroidViewModel` that manages a reactive pipeline:
+### 3. Pre-Populated Database Pattern
 
-1. **Intent reception** — `PublishRelay<Intent>` receives user actions (e.g., `ProfileIntent.SelectSex`)
-2. **Action mapping** — Convert intents to actions via the abstract `intentToAction()` method
-3. **Effect execution** — Run side effects via `actionToResult()`, which returns RxJava Observables
-4. **State reduction** — Combine previous state + result into new state via `stateReducer()`
-5. **State emission** — `BehaviorRelay<ViewModel>` emits to the view layer, always providing the latest state
+**Source:** [`databaseHelper/DatabaseHelper.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/databaseHelper/DatabaseHelper.kt)
 
-### 3. Application-Level State (Cross-Cutting)
+The app opens a pre-populated SQLite database (`nights_out_db.db`, version 40) from `assets/` via `SQLiteOpenHelper`. On upgrade, the `onUpgrade()` method maps old integer IDs to UUIDs using a `SparseArray<UUID>`, drops and rebuilds all tables, then re-inserts saved data. The database ships with ~500+ drink entries covering common beer, wine, liquor, and cocktail types.
 
-`NightsOutApplication` is a minimal `Application` subclass that stores a reference to the current activity (`mCurrentActivity`). This enables:
+### 4. Application-Level State (Cross-Cutting)
 
-- `BacNotificationService` to push live BAC updates back to `HomeFragment` even when the app is not in the foreground
-- Theme initialization and back-stack persistence across activities
+**Source:** [`main/NightsOutApplication.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/NightsOutApplication.kt)
 
-### 4. Pre-Populated Database Pattern
+`NightsOutApplication` stores a reference to the current activity (`mCurrentActivity`). This enables `BacNotificationService` to push live BAC updates back to `HomeFragment` even when the app is not in the foreground. It also initializes ThreeTenABP for date/time support.
 
-The `db` module uses a pre-populated SQLite database (`nights_out_db.db`, version 40) stored in `assets/`. The `SimpleDatabaseManager` copies it to the app's data directory on first use and handles schema migrations during upgrades. The database ships with ~500+ drink entries covering common beer, wine, liquor, and cocktail types.
+### 5. Base Activity Class
 
-### 5. Shared Base Classes (`common`)
+**Source:** [`main/NightsOutActivity.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/NightsOutActivity.kt)
 
-All activities extend `NightsOutActivity` (from `common`), which provides:
-
+All activities (`MainActivity`, `AddDrinkActivity`, `ManageDBActivity`, `SettingsActivity`) extend this abstract class. Key features:
 - Theme loading from SharedPreferences on `onCreate()`
 - Back-stack tracking with configurable max depth (`MAX_BACK_STACK_SIZE = 10`)
-- Instance state saving/restoring for back stack and fragment ID
-- Automatic registration of the activity as the "current" one in `NightsOutApplication`
-- Toast helper methods
+- Notification permission request handling
+- Automatic registration as `NightsOutApplication.mCurrentActivity`
 
 ## Design Decisions & Trade-offs
 
 | Decision | Rationale | Trade-off |
 |----------|-----------|-----------|
 | **Direct SQLite via SQLiteOpenHelper** | Simple, no ORM overhead; ships with rich pre-populated DB | No type safety, manual cursor parsing, fragile on schema changes |
-| **MVI only in profile, not elsewhere** | Profile has complex async state (favorites CRUD); other screens are simple UI | Inconsistent architecture across the codebase; future modules may benefit from MVI |
+| **Flat data binding everywhere** | Single-module simplification after harvesting deprecated submodules | Inconsistent architecture — complex screens (profile favorites) could benefit from MVVM/MVI |
 | **SharedPreferences for all settings** | Simple key-value storage adequate for ~15 preference keys | Not ideal for large-scale persistence; no automatic schema migration |
 | **In-memory state in MainActivity** | Fast access to current session drinks without DB roundtrips | Data loss risk if process is killed before `onStop()` |
-| **Application singleton pattern (NightsOutApplication)** | Enables background service → UI communication | Tight coupling; the `mCurrentActivity` reference must be carefully managed to avoid leaks |
+| **Application singleton pattern** | Enables background service → UI communication | Tight coupling; the `mCurrentActivity` reference must be carefully managed to avoid leaks |
 
-## Build & CI
+## Build Configuration
 
-The project uses a standard Gradle multi-project structure:
-
-- **[CI workflow](../operations/ci-cd.md)** — GitHub Actions builds debug APK and runs unit tests on push to master and all PRs
-- **Java 8 target** required due to AGP 3.6.2 / Gradle wrapper constraints
-- No ProGuard/R8 minification in release builds (`minifyEnabled false`)
+The project uses Gradle Kotlin DSL with a [version catalog](../gradle/libs.versions.toml) (`gradle/libs.versions.toml`) for dependency management. Release builds enable R8 shrinking and ProGuard rules (`proguard-rules.pro`). The CI workflow targets JDK 17 (Temurin), required by AGP 9.3. See **[CI/CD](../operations/ci-cd.md)** for details.
 
 ## Module Structure on Disk
 
 ```
-/build.gradle                          # Top-level: Kotlin plugin, repositories
-/settings.gradle                       # Include :app, :common, :db, :profile, :common-dialog
-/app/                                  # Main Android app
-/common/                               # Shared library module
-/db/                                   # SQLite data layer library
-/profile/                              # MVI profile screen library
-/common-dialog/                        # Dialog component library
-.github/workflows/ci.yml               # CI build + test workflow
-.gradle/ /build/                       # Build output (gitignored)
+/settings.gradle.kts       # include(":app") — single module only
+/app/build.gradle.kts      # Build config: Kotlin DSL, version catalog deps, R8 release
+/gradle/libs.versions.toml # Version catalog (AGP, Kotlin, AndroidX, test libs)
+/.github/workflows/ci.yml  # CI build + test workflow
+/app/src/main/assets/nights_out_db.db  # Pre-populated SQLite database
+.gradle/ /app/build/       # Build output (gitignored)
 ```
+
+The empty directories `/common/`, `/db/`, `/profile/`, and `/common-dialog/` remain on disk but contain no source files — they are vestiges of the previous multi-module structure.

--- a/openwiki/domain/data-model.md
+++ b/openwiki/domain/data-model.md
@@ -1,16 +1,16 @@
 ---
 type: Reference
 title: NightsOut — Data Model
-description: Complete reference for the Drink, LogHeader, VolumeMeasurement, and WeightMeasurement data types used in NightsOut, plus the 5-table SQLite database schema managed by SimpleDatabaseManager.
+description: Complete reference for the Drink, LogHeader, VolumeMeasurement, and WeightMeasurement data types used in NightsOut, plus the 5-table SQLite database schema managed by DatabaseHelper (replacing former SimpleDatabaseManager).
 ---
 
 # Data Model
 
-This page documents all domain types and the database schema powering NightsOut. All model classes live in the `common` module (`/common/src/main/java/com/fagerberg/jason/common/models/`) so they are available to every other module.
+This page documents all domain types and the database schema powering NightsOut. All model classes live in the `:app` module (`/app/src/main/java/com/wit/jasonfagerberg/nightsout/models/`).
 
 ## Drink
 
-**Source:** [`Drink.kt`](/common/src/main/java/com/fagerberg/jason/common/models/Drink.kt)
+**Source:** [`Drink.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/models/Drink.kt)
 
 ```kotlin
 data class Drink (
@@ -30,7 +30,7 @@ The `Drink` data class is the central entity. The `id` is a UUID — introduced 
 
 ## VolumeMeasurement (Enum)
 
-**Source:** [`VolumeMeasurement.kt`](/common/src/main/java/com/fagerberg/jason/common/models/VolumeMeasurement.kt)
+**Source:** [`VolumeMeasurement.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/models/VolumeMeasurement.kt)
 
 ```kotlin
 enum class VolumeMeasurement(val displayName: String) {
@@ -43,7 +43,7 @@ enum class VolumeMeasurement(val displayName: String) {
 }
 ```
 
-Each enum value has a canonical display name and a conversion factor defined in [`ConversionUtils.kt`](/common/src/main/java/com/fagerberg/jason/common/utils/ConversionUtils.kt):
+Each enum value has a canonical display name and a conversion factor defined in [`Converter.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/utils/Converter.kt):
 
 | VolumeMeasurement | Conversion Factor (to fluid oz) | Standard Serving |
 |-------------------|---------------------------------|------------------|
@@ -87,7 +87,7 @@ Derived properties on `LogHeader` include `year`, `month`, `day`, `monthName`, `
 
 ## Database Schema
 
-**Source:** [`SimpleDatabaseManager.kt`](/db/src/main/java/com/wit/jasonfagerberg/nightsout/db/SimpleDatabaseManager.kt)
+**Source:** [`DatabaseHelper.kt`](/app/src/main/java/com/wit/jasonfagerberg/nightsout/databaseHelper/DatabaseHelper.kt)
 
 The database `nights_out_db.db` contains 5 tables:
 

--- a/openwiki/domain/index.md
+++ b/openwiki/domain/index.md
@@ -1,4 +1,4 @@
 # Files
 
 - [NightsOut — BAC Calculation](bac-calculation.md) - Complete reference for the Widmark formula implementation in NightsOut, including unit conversion chains, complex-mix ABV weighting, and the background notification service that recalculates BAC in real time.
-- [NightsOut — Data Model](data-model.md) - Complete reference for the Drink, LogHeader, VolumeMeasurement, and WeightMeasurement data types used in NightsOut, plus the 5-table SQLite database schema managed by SimpleDatabaseManager.
+- [NightsOut — Data Model](data-model.md) - Complete reference for the Drink, LogHeader, VolumeMeasurement, and WeightMeasurement data types used in NightsOut, plus the 5-table SQLite database schema managed by DatabaseHelper (replacing former SimpleDatabaseManager).

--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -4,7 +4,7 @@ okf_version: "0.1"
 
 # Files
 
-- [NightsOut — Quickstart](quickstart.md)
+- [NightsOut — Quickstart](quickstart.md) - Entry point to the NightsOut Android BAC calculator wiki — quick overview, key facts, build instructions, and links to all documentation pages.
 
 # Directories
 

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,7 +1,10 @@
 ---
-type: "Reference"
-title: "NightsOut — Quickstart"
-openwiki_generated: true
+type: Reference
+title: NightsOut — Quickstart
+description: Entry point to the NightsOut Android BAC calculator wiki — quick overview, key facts, build instructions, and links to all documentation pages.
+resource: https://github.com/jasonfagerberg/NightsOut
+tags: [guide, setup]
+timestamp: 2025-07-26T04:00:00Z
 ---
 
 # NightsOut — Quickstart
@@ -10,35 +13,32 @@ openwiki_generated: true
 
 ## What This Wiki Covers
 
-- **[Architecture Overview](./architecture/overview.md)** — Module structure, dependency graph, build configuration, and architectural patterns used across the project
+- **[Architecture Overview](./architecture/overview.md)** — Single-module project structure, build configuration (Kotlin DSL + version catalog), and architectural patterns
 - **[Data Model](./domain/data-model.md)** — The `Drink`, `LogHeader`, `VolumeMeasurement`, and `WeightMeasurement` data types, plus the 5-table SQLite schema
-- **[BAC Calculation](./domain/bac-calculation.md)** — Widmark formula implementation, unit conversion chains, and complex-mix ABV weighting
+- **[BAC Calculation](./domain/bac-calculation.md)** — Widmark formula via `BacCalculator.Drink`/`calculate()`, unit conversion chains, and complex-mix ABV weighting
 - **[User Workflows](./workflows/user-flows.md)** — End-to-end flows: adding drinks, logging sessions, managing profile/favorites, and tracking BAC over time
-- **[App Module](./modules/app.md)** — The main Android app: activities, fragments, RecyclerView adapters, navigation, background services
-- **[Common Module](./modules/common.md)** — Shared domain models, utilities, MVI presenter base class, shared preferences wrapper
-- **[DB Module](./modules/db.md)** — Pre-populated SQLite database with 500+ drink entries and CRUD operations
-- **[Profile Module](./modules/profile.md)** — MVI architecture for user profile management (sex, weight, favorites)
-- **[Common Dialogs](./modules/common-dialog.md)** — Reusable `SimpleDialog` and `LightSimpleDialog` components
-- **[CI/CD](./operations/ci-cd.md)** — GitHub Actions build workflow and Gradle version constraints
-- **[Testing](./testing/overview.md)** — Unit tests (common module) and instrumented tests (db module)
+- **[App Module](./modules/app.md)** — The only Gradle module (`:app`): Activities, Fragments, RecyclerView adapters, navigation, background services
+- **[CI/CD](./operations/ci-cd.md)** — GitHub Actions build workflow, version catalog configuration, and Gradle constraints
+- **[Testing](./testing/overview.md)** — Unit tests for domain models, utility functions, and the `BacCalculator`
 
 ## Key Facts
 
 | Item | Detail |
 |------|--------|
 | **Package name** | `com.wit.jasonfagerberg.nightsout` |
-| **Min SDK** | API 19 (Android 4.4 KitKat) |
+| **Min SDK** | API 24 (Android 7.0 Nougat) |
 | **Target / Compile SDK** | API 36 (Android 16) |
-| **Language** | Kotlin 1.3.72 |
-| **Build system** | Gradle (5 modular projects) |
-| **Database** | SQLite (pre-populated, version 40) |
-| **BAC formula** | Widmark with elimination rate of 0.015 /hr |
+| **Language** | Kotlin |
+| **Build system** | Gradle Kotlin DSL (`build.gradle.kts`) + version catalog (`gradle/libs.versions.toml`), R8 shrinking for release |
+| **Database** | SQLite (pre-populated `nights_out_db.db`, version 40) |
+| **BAC formula** | Widmark with elimination rate of 0.015 /hr, computed by `domain.BacCalculator` |
 
 ## How to Build
 
 ```bash
-./gradlew assembleDebug   # Debug APK
-./gradlew testDebugUnitTest  # Run unit tests
+./gradlew assembleDebug       # Debug APK
+./gradlew testDebugUnitTest   # Run JVM unit tests
+./gradlew assembleRelease     # Release APK (R8 shrinking enabled)
 ```
 
 The CI workflow targets JDK 17 (Temurin), required by AGP 9.3. See **[CI/CD](./operations/ci-cd.md)** for details.
@@ -46,27 +46,31 @@ The CI workflow targets JDK 17 (Temurin), required by AGP 9.3. See **[CI/CD](./o
 ## Architecture at a Glance
 
 ```
-app (UI: Activities, Fragments, Adapters, Services)
-├── depends on → common   (models, utilities, base classes, MVI presenter)
-├── depends on → db       (SQLite data layer, 500+ drink database)
-└── depends on → profile  (MVI user profile screen)
-    └── depends on → common-dialog  (reusable dialog components)
+:app (single Gradle module)
+├── main/java/com/wit/jasonfagerberg/nightsout/
+│   ├── domain/      ← BacCalculator (pure Kotlin, no Android deps)
+│   ├── models/      ← Drink, LogHeader, VolumeMeasurement, WeightMeasurement
+│   ├── utils/       ← Converter, CountryUtils
+│   ├── home/        ← HomeFragment, drink list adapter
+│   ├── addDrink/    ← AddDrinkActivity, ComplexDrinkHelper, suggestions
+│   ├── log/         ← Session logging UI
+│   ├── profile/     ← ProfileFragment + favorites adapter (flat data binding)
+│   ├── notification ← BacNotificationService (foreground service)
+│   └── databaseHelper/ ← DatabaseHelper, AddDrinkDatabaseHelper, LogDatabaseHelper
+└── libs/            ← Local AARs: graphview, material-calendarview
 ```
 
-The app module uses a flat, direct-data-binding pattern for most screens — no ViewModels, LiveData, or Room. The **profile** module is the exception: it implements a full RxJava-based MVI architecture using the `AbstractPresenter` base class from `common`.
+The project is now a **single `:app` module** — the former `:common`, `:db`, `:profile`, and `:common-dialog` submodules were harvested into `:app` in v0.78 (#78). Most screens use direct data binding (no ViewModels, LiveData, or Room). The BAC calculation logic was extracted into a pure-Kotlin object (`domain.BacCalculator`) with dedicated JVM unit tests (#82).
 
 ## Source File Index
 
-| Module | Source Root |
-|--------|-------------|
-| app | `/app/src/main/java/com/wit/jasonfagerberg/nightsout/` |
-| common | `/common/src/main/java/com/fagerberg/jason/common/` |
-| db | `/db/src/main/java/com/wit/jasonfagerberg/nightsout/db/` |
-| profile | `/profile/src/main/java/com/fagerberg/jason/profile/` |
-| common-dialog | `/common-dialog/src/main/java/com/fagerberg/jason/common/dialog/` |
+| Package | Source Root |
+|---------|-------------|
+| All source | `/app/src/main/java/com/wit/jasonfagerberg/nightsout/` |
+| Unit tests | `/app/src/test/java/com/wit/jasonfagerberg/nightsout/` |
+| Version catalog | `gradle/libs.versions.toml` |
 
 ## Backlog
 
-- [ ] **Source map** — Detailed per-module file inventory with roles. Defer until needed.
-- [ ] **Database schema migration history** — Document the 5 version upgrades from v40 onward, including UUID migration. Requires reading `SimpleDatabaseManager.kt` upgrade logic in full.
+- [ ] **Database schema migration history** — Document the 5 version upgrades from v40 onward, including UUID migration. Requires reading `DatabaseHelper.kt` upgrade logic in full.
 - [ ] **Ad integration** — The codebase references rating dialogs (`DRINK_COUNT_TO_ASK_FOR_RATING`, `DAYS_UNTIL_ASK_FOR_RATING`) but the google-services.json was removed; no current ad platform is wired up.


### PR DESCRIPTION
## Why

Local OpenWiki regeneration after the M1 milestone (module deletion, Kotlin DSL, R8) and the Widmark extraction (#82). Stale module docs brought current.

## What changed

`openwiki/` only — 7 files. The `.github/workflows/openwiki-update.yml` local modification is deliberately excluded.

## Verification

Docs-only; CI build/test unaffected.