### PR TITLE
feat: migrate preferences to DataStore (closes #53)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,5 +43,7 @@ dependencies {
     implementation(libs.threetenabp)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.espresso.core)
-    implementation(libs.androidx.preference)
+    // issue #53: DataStore replaces SharedPreferences; koin-android matches the scaffolding PR
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.koin.android)
 }

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/constants/Constants.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/constants/Constants.kt
@@ -61,6 +61,7 @@ class Constants {
             const val USE_24_HOUR_TIME = "homeUse24HourTime"
             const val START_TIME = "homeStartTimeMin"
             const val END_TIME = "homeEndTimeMin"
+            const val IS_BAC_NOTIFICATION_STARTED = "isBacNotificationStarted"
         }
     }
 }

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/di/SettingsModule.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/di/SettingsModule.kt
@@ -1,0 +1,15 @@
+package com.wit.jasonfagerberg.nightsout.di
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.wit.jasonfagerberg.nightsout.settings.SettingsRepository
+import com.wit.jasonfagerberg.nightsout.settings.settingsDataStore
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+// Added to the startKoin module list when this PR and the Koin scaffolding PR
+// (NightsOutApplication + di/AppModule.kt) both land — one-line integration for the merger.
+val settingsModule = module {
+    single<DataStore<Preferences>> { androidContext().settingsDataStore }
+    single { SettingsRepository(get()) }
+}

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/MainActivity.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/MainActivity.kt
@@ -3,7 +3,6 @@ package com.wit.jasonfagerberg.nightsout.main
 // import android.util.Log
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.os.PersistableBundle
@@ -15,7 +14,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import androidx.preference.PreferenceManager
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.wit.jasonfagerberg.nightsout.R
@@ -29,6 +27,7 @@ import com.wit.jasonfagerberg.nightsout.models.LogHeader
 import com.wit.jasonfagerberg.nightsout.models.Drink
 import com.wit.jasonfagerberg.nightsout.notification.BacNotificationService
 import com.wit.jasonfagerberg.nightsout.profile.ProfileFragment
+import com.wit.jasonfagerberg.nightsout.settings.SettingsShim
 import com.wit.jasonfagerberg.nightsout.utils.isCountryThatUses12HourTime
 import java.lang.Exception
 import kotlin.collections.ArrayList
@@ -47,8 +46,9 @@ class MainActivity : NightsOutActivity() {
     private lateinit var pagerAdapter: MyPagerAdapter
     private var prevMenuItem: MenuItem? = null
 
-    // shared pref data
-    private lateinit var preferences: SharedPreferences
+    // persisted settings (blocking shim until #54 wires in SettingsRepository Flows)
+    @Suppress("DEPRECATION")
+    private lateinit var settings: SettingsShim
     var profileInit = false
     var sex: Boolean? = null
     var weight: Double = 0.0
@@ -140,15 +140,16 @@ class MainActivity : NightsOutActivity() {
         mLogHeaders = mDatabaseHelper.pullLogHeaders()
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun getDataFromStorage() {
-        preferences = PreferenceManager.getDefaultSharedPreferences(this)
-        profileInit = preferences.getBoolean(Constants.PREFERENCE.PROFILE_INIT, false)
-        dateInstalled = preferences.getLong(Constants.PREFERENCE.DATE_INSTALLED, System.currentTimeMillis())
-        drinksAddedCount = preferences.getInt(Constants.PREFERENCE.DRINKS_ADDED_COUNT, 0)
-        dontShowRateDialog = preferences.getBoolean(Constants.PREFERENCE.DONT_SHOW_RATE_DIALOG, false)
-        dontShowCurrentBacNotification = preferences.getBoolean(Constants.PREFERENCE.DONT_SHOW_BAC_NOTIFICATION, dontShowCurrentBacNotification)
-        showBacNotification = preferences.getBoolean(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION, true)
-        activeTheme = preferences.getInt(Constants.PREFERENCE.ACTIVE_THEME, R.style.AppTheme)
+        settings = SettingsShim(this)
+        profileInit = settings.getBoolean(Constants.PREFERENCE.PROFILE_INIT, false)
+        dateInstalled = settings.getLong(Constants.PREFERENCE.DATE_INSTALLED, System.currentTimeMillis())
+        drinksAddedCount = settings.getInt(Constants.PREFERENCE.DRINKS_ADDED_COUNT, 0)
+        dontShowRateDialog = settings.getBoolean(Constants.PREFERENCE.DONT_SHOW_RATE_DIALOG, false)
+        dontShowCurrentBacNotification = settings.getBoolean(Constants.PREFERENCE.DONT_SHOW_BAC_NOTIFICATION, dontShowCurrentBacNotification)
+        showBacNotification = settings.getBoolean(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION, true)
+        activeTheme = settings.getInt(Constants.PREFERENCE.ACTIVE_THEME, R.style.AppTheme)
 
         if (showBacNotification) requestNotificationPermissionIfNeeded()
 
@@ -156,15 +157,15 @@ class MainActivity : NightsOutActivity() {
         endTimeMin = Constants.getCurrentTimeInMinuets()
         if (profileInit) {
             sex = true
-            sex = preferences.getBoolean(Constants.PREFERENCE.PROFILE_SEX, sex!!)
+            sex = settings.getBoolean(Constants.PREFERENCE.PROFILE_SEX, sex!!)
             var weightFloat: Float = 0.toFloat()
-            weightFloat = preferences.getFloat(Constants.PREFERENCE.PROFILE_WEIGHT, weightFloat)
+            weightFloat = settings.getFloat(Constants.PREFERENCE.PROFILE_WEIGHT, weightFloat)
             weight = weightFloat.toDouble()
-            weightMeasurement = preferences.getString(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT, weightMeasurement)!!
+            weightMeasurement = settings.getString(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT, weightMeasurement)!!
 
-            use24HourTime = preferences.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, use24HourTime)
-            startTimeMin = preferences.getInt(Constants.PREFERENCE.START_TIME, startTimeMin)
-            endTimeMin = preferences.getInt(Constants.PREFERENCE.END_TIME, endTimeMin)
+            use24HourTime = settings.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, use24HourTime)
+            startTimeMin = settings.getInt(Constants.PREFERENCE.START_TIME, startTimeMin)
+            endTimeMin = settings.getInt(Constants.PREFERENCE.END_TIME, endTimeMin)
         }
 
         if (drinksAddedCount > 10000) setPreference(drinksAddedCount = 10)
@@ -187,6 +188,7 @@ class MainActivity : NightsOutActivity() {
         super.onStop()
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     fun setPreference(profileInit : Boolean = this.profileInit, sex : Boolean? = this.sex,
                       weight : Double = this.weight, weightMeasurement : String = this.weightMeasurement,
                       endTimeMin: Int = this.endTimeMin, startTimeMin : Int = this.startTimeMin,
@@ -208,7 +210,7 @@ class MainActivity : NightsOutActivity() {
         this.dontShowRateDialog = dontShowRateDialog
         this.activeTheme = activeTheme
 
-        val editor = preferences.edit()
+        val editor = settings.edit()
 
         editor.putBoolean(Constants.PREFERENCE.PROFILE_INIT, true)
         if (sex != null) editor.putBoolean(Constants.PREFERENCE.PROFILE_SEX, sex)

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/NightsOutActivity.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/main/NightsOutActivity.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.PersistableBundle
-import androidx.preference.PreferenceManager
 import android.view.Gravity
 import android.view.MenuItem
 import android.widget.Toast
@@ -21,6 +20,7 @@ import com.google.android.material.button.MaterialButton
 import com.wit.jasonfagerberg.nightsout.R
 import com.wit.jasonfagerberg.nightsout.constants.Constants
 import com.wit.jasonfagerberg.nightsout.settings.SettingsActivity
+import com.wit.jasonfagerberg.nightsout.settings.SettingsShim
 import java.util.*
 
 abstract class NightsOutActivity : AppCompatActivity() {
@@ -34,8 +34,9 @@ abstract class NightsOutActivity : AppCompatActivity() {
 
     private var mApp: NightsOutApplication? = null
 
+    @Suppress("DEPRECATION") // shim phase; theme read must stay synchronous pre-setTheme, #54 revisits
     public override fun onCreate(savedInstanceState: Bundle?) {
-        activeTheme = PreferenceManager.getDefaultSharedPreferences(this).getInt("activeTheme", activeTheme)
+        activeTheme = SettingsShim(this).getInt(Constants.PREFERENCE.ACTIVE_THEME, activeTheme)
         setTheme(activeTheme)
         super.onCreate(savedInstanceState)
         mApp = this.applicationContext as NightsOutApplication

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/notification/BacNotificationService.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/notification/BacNotificationService.kt
@@ -6,7 +6,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import androidx.preference.PreferenceManager
 import com.wit.jasonfagerberg.nightsout.R
 import com.wit.jasonfagerberg.nightsout.addDrink.AddDrinkActivity
 import com.wit.jasonfagerberg.nightsout.utils.Converter
@@ -15,6 +14,7 @@ import com.wit.jasonfagerberg.nightsout.domain.BacCalculator
 import com.wit.jasonfagerberg.nightsout.constants.Constants
 import com.wit.jasonfagerberg.nightsout.main.MainActivity
 import com.wit.jasonfagerberg.nightsout.main.NightsOutApplication
+import com.wit.jasonfagerberg.nightsout.settings.SettingsShim
 
 
 class BacNotificationService : Service() {
@@ -51,8 +51,9 @@ class BacNotificationService : Service() {
         isStarted = isNotificationActive()
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun isNotificationActive() : Boolean {
-        return PreferenceManager.getDefaultSharedPreferences(this).getBoolean("isBacNotificationStarted", false)
+        return SettingsShim(this).getBoolean(Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED, false)
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
@@ -110,18 +111,20 @@ class BacNotificationService : Service() {
                         mConverter.timeToString(endTime/60, endTime%60, use24HourTime), false)
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun getPreferencesData() {
-        val preferences = PreferenceManager.getDefaultSharedPreferences(this)
-        startTime = preferences.getInt(Constants.PREFERENCE.START_TIME, 0)
-        endTime = preferences.getInt(Constants.PREFERENCE.END_TIME, 0)
-        use24HourTime = preferences.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, false)
-        sex = preferences.getBoolean(Constants.PREFERENCE.PROFILE_SEX, true)
-        weight = preferences.getFloat(Constants.PREFERENCE.PROFILE_WEIGHT, 0.toFloat()).toDouble()
-        weightMeasurement = preferences.getString(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT, "oz")!!
+        val settings = SettingsShim(this)
+        startTime = settings.getInt(Constants.PREFERENCE.START_TIME, 0)
+        endTime = settings.getInt(Constants.PREFERENCE.END_TIME, 0)
+        use24HourTime = settings.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, false)
+        sex = settings.getBoolean(Constants.PREFERENCE.PROFILE_SEX, true)
+        weight = settings.getFloat(Constants.PREFERENCE.PROFILE_WEIGHT, 0.toFloat()).toDouble()
+        weightMeasurement = settings.getString(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT, "oz")!!
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun saveEndTime() {
-        val editor = PreferenceManager.getDefaultSharedPreferences(this).edit()
+        val editor = SettingsShim(this).edit()
         editor.putInt(Constants.PREFERENCE.END_TIME, endTime)
         editor.apply()
     }
@@ -145,9 +148,10 @@ class BacNotificationService : Service() {
         return null
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun saveNotificationState(started : Boolean) {
-        val editor = PreferenceManager.getDefaultSharedPreferences(this).edit()
-        editor.putBoolean("isBacNotificationStarted", started)
+        val editor = SettingsShim(this).edit()
+        editor.putBoolean(Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED, started)
         editor.apply()
     }
 }

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/profile/ProfileFragment.kt
@@ -3,7 +3,6 @@ package com.wit.jasonfagerberg.nightsout.profile
 import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
-import androidx.preference.PreferenceManager
 import com.google.android.material.button.MaterialButton
 import androidx.fragment.app.Fragment
 import androidx.core.content.ContextCompat
@@ -30,6 +29,7 @@ import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import androidx.recyclerview.widget.ItemTouchHelper
 import com.wit.jasonfagerberg.nightsout.addDrink.AddDrinkActivity
+import com.wit.jasonfagerberg.nightsout.settings.SettingsShim
 import com.wit.jasonfagerberg.nightsout.utils.Converter
 import com.wit.jasonfagerberg.nightsout.dialogs.LightSimpleDialog
 
@@ -54,20 +54,22 @@ class ProfileFragment : Fragment() {
     private var weightMeasurement = if (country == "US" || country == "LR" || country == "MM") "lbs"
     else "kg"
 
+    // legacy draft cache; #54's profile ViewModel subsumes it via SettingsRepository
+    @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         mMainActivity = context as MainActivity
         mMainActivity.profileFragment = this
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val sexInt = preferences.getInt("SEX", -1)
+        val settings = SettingsShim(requireContext())
+        val sexInt = settings.getInt("SEX", -1)
         if (sexInt > 0) sex = sexInt == 1
-        weight = preferences.getFloat("WEIGHT", weight.toFloat()).toDouble()
-        weightMeasurement = preferences.getString("MEASUREMENT", weightMeasurement)!!
+        weight = settings.getFloat("WEIGHT", weight.toFloat()).toDouble()
+        weightMeasurement = settings.getString("MEASUREMENT", weightMeasurement)!!
         super.onCreate(savedInstanceState)
     }
 
+    @Suppress("DEPRECATION")
     override fun onPause() {
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val editor = preferences.edit()
+        val editor = SettingsShim(requireContext()).edit()
         val sexInt = if (sex == null) -1 else if (sex == true) 1 else 0
         editor.putInt("SEX", sexInt)
         editor.putFloat("WEIGHT", weight.toFloat())

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsActivity.kt
@@ -2,7 +2,6 @@ package com.wit.jasonfagerberg.nightsout.settings
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.preference.PreferenceManager
 import android.view.MenuItem
 import android.widget.CheckBox
 import android.widget.ImageButton
@@ -104,16 +103,18 @@ class SettingsActivity : NightsOutActivity() {
         }
     }
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun getNotificationStatus() {
-        val pref = PreferenceManager.getDefaultSharedPreferences(this)
-        showCurrentBacNotification = pref.getBoolean(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION, true)
-        use24HourTime = pref.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, false)
-        profileInit = pref.getBoolean(Constants.PREFERENCE.PROFILE_INIT, false)
+        val settings = SettingsShim(this)
+        showCurrentBacNotification = settings.getBoolean(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION, true)
+        use24HourTime = settings.getBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, false)
+        profileInit = settings.getBoolean(Constants.PREFERENCE.PROFILE_INIT, false)
     }
 
 
+    @Suppress("DEPRECATION") // shim phase; #54 replaces with SettingsRepository
     private fun setSetting(showCurrentBacNotification : Boolean = true, activeTheme : Int = this.activeTheme, use24HourTime : Boolean = this.use24HourTime) {
-        val edit = PreferenceManager.getDefaultSharedPreferences(this).edit()
+        val edit = SettingsShim(this).edit()
         edit.putBoolean(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION, showCurrentBacNotification)
         edit.putInt(Constants.PREFERENCE.ACTIVE_THEME, activeTheme)
         edit.putBoolean(Constants.PREFERENCE.USE_24_HOUR_TIME, use24HourTime)

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsKeys.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsKeys.kt
@@ -1,0 +1,27 @@
+package com.wit.jasonfagerberg.nightsout.settings
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.wit.jasonfagerberg.nightsout.constants.Constants
+
+// Names intentionally match the legacy SharedPreferences keys so SharedPreferencesMigration
+// carries existing users' values over unchanged.
+object SettingsKeys {
+    val PROFILE_INIT = booleanPreferencesKey(Constants.PREFERENCE.PROFILE_INIT)
+    val DATE_INSTALLED = longPreferencesKey(Constants.PREFERENCE.DATE_INSTALLED)
+    val DRINKS_ADDED_COUNT = intPreferencesKey(Constants.PREFERENCE.DRINKS_ADDED_COUNT)
+    val DONT_SHOW_RATE_DIALOG = booleanPreferencesKey(Constants.PREFERENCE.DONT_SHOW_RATE_DIALOG)
+    val DONT_SHOW_BAC_NOTIFICATION = booleanPreferencesKey(Constants.PREFERENCE.DONT_SHOW_BAC_NOTIFICATION)
+    val SHOW_BAC_NOTIFICATION = booleanPreferencesKey(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION)
+    val ACTIVE_THEME = intPreferencesKey(Constants.PREFERENCE.ACTIVE_THEME)
+    val PROFILE_SEX = booleanPreferencesKey(Constants.PREFERENCE.PROFILE_SEX)
+    val PROFILE_WEIGHT = floatPreferencesKey(Constants.PREFERENCE.PROFILE_WEIGHT)
+    val PROFILE_WEIGHT_MEASUREMENT = stringPreferencesKey(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT)
+    val USE_24_HOUR_TIME = booleanPreferencesKey(Constants.PREFERENCE.USE_24_HOUR_TIME)
+    val START_TIME = intPreferencesKey(Constants.PREFERENCE.START_TIME)
+    val END_TIME = intPreferencesKey(Constants.PREFERENCE.END_TIME)
+    val IS_BAC_NOTIFICATION_STARTED = booleanPreferencesKey(Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED)
+}

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsRepository.kt
@@ -1,0 +1,63 @@
+package com.wit.jasonfagerberg.nightsout.settings
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import com.wit.jasonfagerberg.nightsout.R
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// Process-wide single DataStore (the delegate caches by name). The migration name is the
+// default SharedPreferences file (PreferenceManager's "<package>_preferences"), so existing
+// users keep their settings on first access.
+internal val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+    produceMigrations = { context ->
+        listOf(SharedPreferencesMigration(context, "${context.packageName}_preferences"))
+    }
+)
+
+// The real settings API: Flow reads and suspend writes per key. #54 (ViewModels) consumes
+// this directly; until then call sites go through the blocking SettingsShim bridge.
+class SettingsRepository(private val dataStore: DataStore<Preferences>) {
+
+    val profileInit: Flow<Boolean> = read(SettingsKeys.PROFILE_INIT, false)
+    val dateInstalled: Flow<Long> = read(SettingsKeys.DATE_INSTALLED, 0L)
+    val drinksAddedCount: Flow<Int> = read(SettingsKeys.DRINKS_ADDED_COUNT, 0)
+    val dontShowRateDialog: Flow<Boolean> = read(SettingsKeys.DONT_SHOW_RATE_DIALOG, false)
+    val dontShowBacNotification: Flow<Boolean> = read(SettingsKeys.DONT_SHOW_BAC_NOTIFICATION, false)
+    val showBacNotification: Flow<Boolean> = read(SettingsKeys.SHOW_BAC_NOTIFICATION, true)
+    val activeTheme: Flow<Int> = read(SettingsKeys.ACTIVE_THEME, R.style.AppTheme)
+    val profileSex: Flow<Boolean> = read(SettingsKeys.PROFILE_SEX, true)
+    val profileWeight: Flow<Float> = read(SettingsKeys.PROFILE_WEIGHT, 0f)
+    val profileWeightMeasurement: Flow<String> = read(SettingsKeys.PROFILE_WEIGHT_MEASUREMENT, "")
+    val use24HourTime: Flow<Boolean> = read(SettingsKeys.USE_24_HOUR_TIME, false)
+    val startTimeMin: Flow<Int> = read(SettingsKeys.START_TIME, 0)
+    val endTimeMin: Flow<Int> = read(SettingsKeys.END_TIME, 0)
+    val isBacNotificationStarted: Flow<Boolean> = read(SettingsKeys.IS_BAC_NOTIFICATION_STARTED, false)
+
+    suspend fun setProfileInit(value: Boolean) = write(SettingsKeys.PROFILE_INIT, value)
+    suspend fun setDateInstalled(value: Long) = write(SettingsKeys.DATE_INSTALLED, value)
+    suspend fun setDrinksAddedCount(value: Int) = write(SettingsKeys.DRINKS_ADDED_COUNT, value)
+    suspend fun setDontShowRateDialog(value: Boolean) = write(SettingsKeys.DONT_SHOW_RATE_DIALOG, value)
+    suspend fun setDontShowBacNotification(value: Boolean) = write(SettingsKeys.DONT_SHOW_BAC_NOTIFICATION, value)
+    suspend fun setShowBacNotification(value: Boolean) = write(SettingsKeys.SHOW_BAC_NOTIFICATION, value)
+    suspend fun setActiveTheme(value: Int) = write(SettingsKeys.ACTIVE_THEME, value)
+    suspend fun setProfileSex(value: Boolean) = write(SettingsKeys.PROFILE_SEX, value)
+    suspend fun setProfileWeight(value: Float) = write(SettingsKeys.PROFILE_WEIGHT, value)
+    suspend fun setProfileWeightMeasurement(value: String) = write(SettingsKeys.PROFILE_WEIGHT_MEASUREMENT, value)
+    suspend fun setUse24HourTime(value: Boolean) = write(SettingsKeys.USE_24_HOUR_TIME, value)
+    suspend fun setStartTimeMin(value: Int) = write(SettingsKeys.START_TIME, value)
+    suspend fun setEndTimeMin(value: Int) = write(SettingsKeys.END_TIME, value)
+    suspend fun setIsBacNotificationStarted(value: Boolean) = write(SettingsKeys.IS_BAC_NOTIFICATION_STARTED, value)
+
+    private fun <T> read(key: Preferences.Key<T>, default: T): Flow<T> =
+        dataStore.data.map { it[key] ?: default }
+
+    private suspend fun <T> write(key: Preferences.Key<T>, value: T) {
+        dataStore.edit { it[key] = value }
+    }
+}

--- a/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsShim.kt
+++ b/app/src/main/java/com/wit/jasonfagerberg/nightsout/settings/SettingsShim.kt
@@ -1,0 +1,68 @@
+package com.wit.jasonfagerberg.nightsout.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+// TEMPORARY BRIDGE for issue #53: SharedPreferences-shaped blocking facade over DataStore,
+// so call sites migrate with no behavior change. Issue #54 (ViewModel migration) consumes
+// SettingsRepository Flows directly and DELETES this class. Do not add new usages.
+@Deprecated("Temporary bridge — removed by #54 ViewModel migration")
+class SettingsShim(context: Context) {
+
+    private val dataStore = context.applicationContext.settingsDataStore
+
+    fun getBoolean(key: String, defValue: Boolean): Boolean = runBlocking {
+        dataStore.data.first()[booleanPreferencesKey(key)] ?: defValue
+    }
+
+    fun getInt(key: String, defValue: Int): Int = runBlocking {
+        dataStore.data.first()[intPreferencesKey(key)] ?: defValue
+    }
+
+    fun getLong(key: String, defValue: Long): Long = runBlocking {
+        dataStore.data.first()[longPreferencesKey(key)] ?: defValue
+    }
+
+    fun getFloat(key: String, defValue: Float): Float = runBlocking {
+        dataStore.data.first()[floatPreferencesKey(key)] ?: defValue
+    }
+
+    fun getString(key: String, defValue: String?): String? = runBlocking {
+        dataStore.data.first()[stringPreferencesKey(key)] ?: defValue
+    }
+
+    fun edit(): Editor = Editor()
+
+    // Mirrors SharedPreferences.Editor: stage puts, persist in one DataStore transaction.
+    inner class Editor {
+        private val staged = mutableMapOf<Preferences.Key<*>, Any>()
+
+        fun putBoolean(key: String, value: Boolean) = apply { staged[booleanPreferencesKey(key)] = value }
+        fun putInt(key: String, value: Int) = apply { staged[intPreferencesKey(key)] = value }
+        fun putLong(key: String, value: Long) = apply { staged[longPreferencesKey(key)] = value }
+        fun putFloat(key: String, value: Float) = apply { staged[floatPreferencesKey(key)] = value }
+
+        // null is a no-op: DataStore can't store nulls and no call site ever writes one
+        fun putString(key: String, value: String?) = apply {
+            if (value != null) staged[stringPreferencesKey(key)] = value
+        }
+
+        fun apply() = runBlocking {
+            dataStore.edit { prefs -> staged.forEach { (key, value) -> prefs.putUnchecked(key, value) } }
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun MutablePreferences.putUnchecked(key: Preferences.Key<*>, value: Any) {
+    this[key as Preferences.Key<Any>] = value
+}

--- a/app/src/test/java/com/wit/jasonfagerberg/nightsout/settings/SettingsKeysTest.kt
+++ b/app/src/test/java/com/wit/jasonfagerberg/nightsout/settings/SettingsKeysTest.kt
@@ -1,0 +1,44 @@
+package com.wit.jasonfagerberg.nightsout.settings
+
+import com.wit.jasonfagerberg.nightsout.constants.Constants
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SettingsKeysTest {
+
+    @Test
+    fun `datastore keys are built from the Constants preference names`() {
+        assertThat(SettingsKeys.PROFILE_INIT.name).isEqualTo(Constants.PREFERENCE.PROFILE_INIT)
+        assertThat(SettingsKeys.DATE_INSTALLED.name).isEqualTo(Constants.PREFERENCE.DATE_INSTALLED)
+        assertThat(SettingsKeys.DRINKS_ADDED_COUNT.name).isEqualTo(Constants.PREFERENCE.DRINKS_ADDED_COUNT)
+        assertThat(SettingsKeys.DONT_SHOW_RATE_DIALOG.name).isEqualTo(Constants.PREFERENCE.DONT_SHOW_RATE_DIALOG)
+        assertThat(SettingsKeys.DONT_SHOW_BAC_NOTIFICATION.name).isEqualTo(Constants.PREFERENCE.DONT_SHOW_BAC_NOTIFICATION)
+        assertThat(SettingsKeys.SHOW_BAC_NOTIFICATION.name).isEqualTo(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION)
+        assertThat(SettingsKeys.ACTIVE_THEME.name).isEqualTo(Constants.PREFERENCE.ACTIVE_THEME)
+        assertThat(SettingsKeys.PROFILE_SEX.name).isEqualTo(Constants.PREFERENCE.PROFILE_SEX)
+        assertThat(SettingsKeys.PROFILE_WEIGHT.name).isEqualTo(Constants.PREFERENCE.PROFILE_WEIGHT)
+        assertThat(SettingsKeys.PROFILE_WEIGHT_MEASUREMENT.name).isEqualTo(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT)
+        assertThat(SettingsKeys.USE_24_HOUR_TIME.name).isEqualTo(Constants.PREFERENCE.USE_24_HOUR_TIME)
+        assertThat(SettingsKeys.START_TIME.name).isEqualTo(Constants.PREFERENCE.START_TIME)
+        assertThat(SettingsKeys.END_TIME.name).isEqualTo(Constants.PREFERENCE.END_TIME)
+        assertThat(SettingsKeys.IS_BAC_NOTIFICATION_STARTED.name).isEqualTo(Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED)
+    }
+
+    @Test
+    fun `preference names are unchanged so existing users migrate from SharedPreferences`() {
+        assertThat(Constants.PREFERENCE.PROFILE_INIT).isEqualTo("profileInit")
+        assertThat(Constants.PREFERENCE.DATE_INSTALLED).isEqualTo("dateInstalled")
+        assertThat(Constants.PREFERENCE.DRINKS_ADDED_COUNT).isEqualTo("drinksAddedCount")
+        assertThat(Constants.PREFERENCE.DONT_SHOW_RATE_DIALOG).isEqualTo("dontShowRateDialog")
+        assertThat(Constants.PREFERENCE.DONT_SHOW_BAC_NOTIFICATION).isEqualTo("dontShowCurrentBacNotification")
+        assertThat(Constants.PREFERENCE.SHOW_BAC_NOTIFICATION).isEqualTo("showCurrentBacNotification")
+        assertThat(Constants.PREFERENCE.ACTIVE_THEME).isEqualTo("activeTheme")
+        assertThat(Constants.PREFERENCE.PROFILE_SEX).isEqualTo("profileSex")
+        assertThat(Constants.PREFERENCE.PROFILE_WEIGHT).isEqualTo("profileWeight")
+        assertThat(Constants.PREFERENCE.PROFILE_WEIGHT_MEASUREMENT).isEqualTo("profileWeightMeasurement")
+        assertThat(Constants.PREFERENCE.USE_24_HOUR_TIME).isEqualTo("homeUse24HourTime")
+        assertThat(Constants.PREFERENCE.START_TIME).isEqualTo("homeStartTimeMin")
+        assertThat(Constants.PREFERENCE.END_TIME).isEqualTo("homeEndTimeMin")
+        assertThat(Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED).isEqualTo("isBacNotificationStarted")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,24 +4,27 @@ viewpager = "1.0.0"
 appcompat = "1.1.0"
 material = "1.1.0"
 constraintlayout = "1.1.3"
-preference = "1.1.1"
 threetenabp = "1.1.1"
 junit = "4.12"
 assertj = "3.12.2"
 androidx-test = "1.2.0"
 espresso = "3.2.0"
+# issue #53 (datastore) / koin version+alias kept identical to the Koin scaffolding PR for a clean merge
+datastore = "1.2.1"
+koin = "4.2.2"
 
 [libraries]
 androidx-viewpager = { group = "androidx.viewpager", name = "viewpager", version.ref = "viewpager" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "preference" }
 threetenabp = { group = "com.jakewharton.threetenabp", name = "threetenabp", version.ref = "threetenabp" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Why

Every settings read/write in the app goes through `PreferenceManager.getDefaultSharedPreferences(...)` on the calling thread (issue #53). SharedPreferences has no async API and no error signaling; the project standard is coroutines/Flow. This PR moves all persisted settings to a Preferences DataStore without changing any observable behavior.

## What changed

- **Deps**: added `androidx.datastore:datastore-preferences:1.2.1` (latest stable; 1.3.0 is alpha-only) and `io.insert-koin:koin-android:4.2.2`; removed `androidx.preference` (nothing uses it after this). The koin version/alias intentionally matches the Koin scaffolding PR so the catalog merge is trivial.
- **`settings/SettingsKeys.kt`** — typed DataStore keys for all 14 migrated keys: the 13 `Constants.PREFERENCE` keys plus `isBacNotificationStarted` (previously a hardcoded string in `BacNotificationService`, now `Constants.PREFERENCE.IS_BAC_NOTIFICATION_STARTED`). Names are byte-identical to the legacy SharedPreferences keys.
- **`settings/SettingsRepository.kt`** — the real API: one `Flow` read and one `suspend` write per key, backed by a single `preferencesDataStore` delegate. A `SharedPreferencesMigration` off the default `"<package>_preferences"` file carries existing users' values over on first access (the migration skips keys already present, so nothing is clobbered).
- **`settings/SettingsShim.kt`** — temporary compatibility bridge, see How.
- **`di/SettingsModule.kt`** — Koin bindings (`DataStore<Preferences>` + `SettingsRepository`). New file per coordination plan: it joins the `startKoin` module list when this and the scaffolding PR (`di/AppModule.kt`) both land — one-line integration for the merger.
- **Call sites migrated off `PreferenceManager`**: `MainActivity` (`getDataFromStorage`/`setPreference`, named-parameter style preserved), `NightsOutActivity` (synchronous theme read before `setTheme`), `SettingsActivity` (`getNotificationStatus`/`setSetting`), `BacNotificationService` (`getPreferencesData`/`saveEndTime`/`saveNotificationState`/`isNotificationActive`), and `ProfileFragment` (legacy `SEX`/`WEIGHT`/`MEASUREMENT` draft cache, unchanged key names).
- **Tests**: `SettingsKeysTest` (JVM-pure, +2 tests → 23 total) guards the key-name mapping so the migration contract can't silently break.

## How

Two-layer design. `SettingsRepository` is the async API #54's ViewModels will consume (Flow reads, suspend writes, DI-provided). Since no ViewModels exist yet, call sites go through `SettingsShim`: a `@Deprecated("Temporary bridge — removed by #54 ViewModel migration")` facade with SharedPreferences-shaped `get*`/`edit()`/`put*`/`apply()` methods implemented with `runBlocking` over the same DataStore. Defaults (`SHOW_BAC_NOTIFICATION` true, weight `0f`, theme `R.style.AppTheme`, etc.) and write-through semantics are exactly preserved; batched edits commit in one DataStore transaction.

**The unshim contract**: `SettingsShim` is temporary. Issue #54 deletes it, injects `SettingsRepository` into the new ViewModels, and removes every `@Suppress("DEPRECATION") // shim phase` marker this PR leaves at the migrated call sites.

## Verification

`./gradlew clean assembleDebug assembleRelease testDebugUnitTest` — all pass. 23 unit tests, 0 failures (21 pre-existing + 2 new). No Robolectric or instrumented tests added per scope; DataStore runtime behavior (migration on upgrade, notification service round-trip, theme apply) is on the manual device-test list.

## Out of scope

- Shim removal and Flow consumption — issue #54.
- Wiring `settingsModule` into `startKoin` — one-line integration handled when the Koin scaffolding PR merges.
- Manual device test of the SharedPreferences → DataStore migration on an installed build.