### PR TITLE
chore: enable Dependabot for gradle and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      # one PR/week instead of one per dependency
+      gradle-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the two ecosystems that apply here: `gradle` (picks up `gradle/libs.versions.toml` and the build files) and `github-actions` (keeps `actions/checkout`, `actions/setup-java`, etc. current).
- Both run weekly with updates grouped into a single PR per ecosystem per week, and `open-pull-requests-limit: 3` so this stays quiet on a small hobby repo instead of flooding it with one PR per dependency.
- Style follows the conventions in `fagerbergj/quack`'s own `.github/dependabot.yml`.

## Test plan
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly
- [ ] Dependabot picks up the config and opens its first grouped PRs on schedule